### PR TITLE
Add definitions of r blades and multivectors

### DIFF
--- a/src/geometric_algebra/nursery/chisolm.lean
+++ b/src/geometric_algebra/nursery/chisolm.lean
@@ -69,6 +69,28 @@ local infix `*₊`:75 := sym_prod
 
 local infix `*₊ᵥ`:75 := sym_prod_vec
 
+
+def is_orthogonal (a : G₁) (b : G₁) : Prop := sym_prod_vec a b = 0
+
+theorem zero_is_orthogonal (a : G₁) : is_orthogonal 0 a := begin
+  unfold is_orthogonal,
+  unfold sym_prod_vec,
+  unfold prod_vec,
+  simp
+end
+
+class inductive blade (b : G): nat → Type u
+| scalar :
+  -- equals a scalar
+  (∃ (k: G₀),
+   b = fₛ k)
+  → blade 0
+| graded {n : ℕ} :
+  -- or a product of orthogonal vectors
+  (∃ (v : {l : vector G₁ (n + 1) // l.val.pairwise (λ a b, is_orthogonal a b ∧ a ≠ b)}),
+   b = list.foldl (λ (b : G) (a : G₁), fᵥ a * b) (fᵥ v.val.head) v.val.tail.val)
+  → blade(n + 1)
+
 /-
   Symmetrised product of two vectors must be a scalar
 -/
@@ -104,6 +126,17 @@ exists.elim (vec_sq_scalar (a + b))
     )
   )
 )
+
+/- The scalars are 0-blades, as is the result of the vector/vector sym_prod -/
+instance scalar_blade0 (a : G₀) : blade (fₛ a) 0 := blade.scalar (by use a)
+instance vec_sym_prod_blade0 (a b : G₁) : blade (a *₊ᵥ b) 0 := blade.scalar (vec_sym_prod_scalar a b)
+
+/- The vectors are 1-blades -/
+instance vector_blade1 (a : G₁) : blade (fᵥ a) 1 := blade.graded (begin
+  use ⟨(vector.cons a vector.nil), list.pairwise_singleton _ _⟩,
+  unfold vector.nil,
+  simp,
+end)
 
 end
 

--- a/src/geometric_algebra/nursery/chisolm.lean
+++ b/src/geometric_algebra/nursery/chisolm.lean
@@ -161,14 +161,14 @@ end Bᵣ
 def Gᵣ (r : ℕ) := add_subgroup.closure (Bᵣ r)
 namespace Gᵣ
   variables {r : ℕ}
-  instance addgroup : add_group (Gᵣ r) := (Gᵣ r).to_add_group
+  instance addgroup : add_comm_group (Gᵣ r) := (Gᵣ r).to_add_comm_group
 end Gᵣ
 
 -- multi-vectors
 def Mᵣ (r : ℕ) := add_subgroup.closure (⋃ (r : ℕ), (Gᵣ r).carrier)
 namespace Mᵣ
   variables {r : ℕ}
-  instance addgroup : add_group (Mᵣ r) := (Mᵣ r).to_add_group
+  instance addgroup : add_comm_group (Mᵣ r) := (Mᵣ r).to_add_comm_group
 end Mᵣ
 
 @[simp]

--- a/src/geometric_algebra/nursery/chisolm.lean
+++ b/src/geometric_algebra/nursery/chisolm.lean
@@ -155,6 +155,7 @@ namespace Bᵣ
   def neg (b : Bᵣ r) : Bᵣ r := ⟨-b.val, neg_rblade_is_rblade b.property⟩
 
   instance has_neg (r : ℕ) : has_neg (Bᵣ r) := { neg := neg}
+
 end Bᵣ
 
 -- r-vectors
@@ -164,6 +165,14 @@ example (r : ℕ) : add_comm_group (Gᵣ r) := by apply_instance
 -- multi-vectors
 def Mᵣ (r : ℕ) := add_subgroup.closure (⋃ (r : ℕ), (Gᵣ r).carrier)
 example (r : ℕ) : add_comm_group (Mᵣ r) := by apply_instance
+
+  
+def grade_select {r : ℕ} (m : Mᵣ r) (g : ℕ) : Gᵣ g := sorry
+
+lemma grade_iff {r : ℕ} {a : Mᵣ r} {g : ℕ} : a ∈ Gᵣ g ↔ a = grade_select a g := sorry
+lemma grade_add {r : ℕ} {a b : Mᵣ r} {g : ℕ} : grade_select (a + b) g = grade_select a g + grade_select b g:= sorry
+lemma grade_scale {r : ℕ} {a : Mᵣ r} {k : G₀} {g : ℕ} : grade_select (k*a) g = k * grade_select a g := sorry
+lemma grade_compose {r : ℕ} {a : Mᵣ r} {g1 : ℕ} {g2 : ℕ} : grade_select (grade_select a g1) g2 = if g1 = g2 then grade_select a g1 else 0 := sorry
 
 @[simp]
 def is_scalar : G → Prop := is_rblade 0

--- a/src/geometric_algebra/nursery/chisolm.lean
+++ b/src/geometric_algebra/nursery/chisolm.lean
@@ -132,10 +132,10 @@ namespace Bᵣ
   instance has_coe_from_G₀ : has_coe G₀ (Bᵣ 0) := { coe := λ k, ⟨fₛ k, all_G₀_is_rblade0 k⟩}
   instance has_coe_from_G₁ : has_coe G₁ (Bᵣ 1) := { coe := λ a, ⟨fᵥ a, all_G₁_is_rblade1 a⟩}
 
-  -- these are trivial, but somehow still needed
+  -- these are trivial, but maybe still needed
   instance has_coe_to_G : has_coe (Bᵣ r) G := { coe := subtype.val }
   @[simp]
-  lemma is_rblade (b : Bᵣ r) : is_rblade r b := b.property
+  lemma coe_is_rblade (b : Bᵣ r) : is_rblade r b := b.property
 
   /- todo: do we want this? -/
   -- instance has_zero : has_zero (Bᵣ r) := {
@@ -145,14 +145,14 @@ namespace Bᵣ
   --   end⟩ 
   -- }
 
-  def neg (b : Bᵣ r) : Bᵣ r := ⟨-b.val, begin
-    cases b with b' hb,
+  lemma neg_rblade_is_rblade {b : G} (hb : is_rblade r b) : (is_rblade r (-b)) := begin
     exact exists.elim hb begin
       intros a ha,
       use -a,
       simp [ha],
     end
-  end⟩
+  end
+  def neg (b : Bᵣ r) : Bᵣ r := ⟨-b.val, neg_rblade_is_rblade b.property⟩
 
   instance has_neg (r : ℕ) : has_neg (Bᵣ r) := { neg := neg}
 end Bᵣ

--- a/src/geometric_algebra/nursery/chisolm.lean
+++ b/src/geometric_algebra/nursery/chisolm.lean
@@ -145,14 +145,42 @@ namespace Bᵣ
   --   end⟩ 
   -- }
 
-  lemma neg_rblade_is_rblade {b : G} (hb : is_rblade r b) : (is_rblade r (-b)) := begin
+  -- scalar multiplication remains an r-blade
+  lemma mul_rblade_is_rblade {b : G} {k : G₀} (hb : is_rblade r b) : (is_rblade r ((fₛ k) * b)) := begin
     exact exists.elim hb begin
       intros a ha,
-      use -a,
-      simp [ha],
+      use k*a,
+      exact exists.elim ha begin
+        intros a_1 ha_1,
+        use a_1,
+        rw ha_1,
+        rw ring_hom.map_mul,
+        rw mul_assoc
+      end
     end
   end
+  /- this one is hard, we need to show scalars commute -/
+  lemma rblade_mul_is_rblade {b : G} {k : G₀} (hb : is_rblade r b) : (is_rblade r (b * (fₛ k))) := sorry
+  lemma neg_rblade_is_rblade {b : G} (hb : is_rblade r b) : (is_rblade r (-b)) := begin
+    rw neg_eq_neg_one_mul,
+    rw ← ring_hom.map_one fₛ,
+    rw ← ring_hom.map_neg fₛ,
+    exact mul_rblade_is_rblade hb,
+  end
+
+
   def neg (b : Bᵣ r) : Bᵣ r := ⟨-b.val, neg_rblade_is_rblade b.property⟩
+  def smul (k : G₀) (b : Bᵣ r) : Bᵣ r := ⟨(fₛ k) * b.val, mul_rblade_is_rblade b.property⟩ 
+
+  instance Bᵣ_has_scalar (r : ℕ) : has_scalar G₀ (Bᵣ r) := { smul := smul }
+  
+  def rblade_smul_one_is_self (b : Bᵣ r) : smul (1 : G₀) b = b := by simp [smul]
+  def rblade_smul_assoc (k1 k2 : G₀) (b : Bᵣ r) : smul (k1 * k2) b =  smul k1 (smul k2 b) := by simp [smul, mul_assoc]
+
+  instance Bᵣ_mul_action : mul_action G₀ (Bᵣ r):= {
+    one_smul := rblade_smul_one_is_self,
+    mul_smul := rblade_smul_assoc, 
+    ..Bᵣ_has_scalar r}
 
   instance has_neg (r : ℕ) : has_neg (Bᵣ r) := { neg := neg}
 
@@ -161,6 +189,9 @@ end Bᵣ
 -- r-vectors
 def Gᵣ (r : ℕ) := add_subgroup.closure (Bᵣ r)
 example (r : ℕ) : add_comm_group (Gᵣ r) := by apply_instance
+namespace Gᵣ
+  instance Gᵣ_semimodule (r : ℕ) : semimodule G₀ (Gᵣ r) := sorry
+end Gᵣ
 
 -- multi-vectors
 def Mᵣ (r : ℕ) := add_subgroup.closure (⋃ (r : ℕ), (Gᵣ r).carrier)

--- a/src/geometric_algebra/nursery/chisolm.lean
+++ b/src/geometric_algebra/nursery/chisolm.lean
@@ -159,17 +159,11 @@ end Bᵣ
 
 -- r-vectors
 def Gᵣ (r : ℕ) := add_subgroup.closure (Bᵣ r)
-namespace Gᵣ
-  variables {r : ℕ}
-  instance addgroup : add_comm_group (Gᵣ r) := (Gᵣ r).to_add_comm_group
-end Gᵣ
+example (r : ℕ) : add_comm_group (Gᵣ r) := by apply_instance
 
 -- multi-vectors
 def Mᵣ (r : ℕ) := add_subgroup.closure (⋃ (r : ℕ), (Gᵣ r).carrier)
-namespace Mᵣ
-  variables {r : ℕ}
-  instance addgroup : add_comm_group (Mᵣ r) := (Mᵣ r).to_add_comm_group
-end Mᵣ
+example (r : ℕ) : add_comm_group (Mᵣ r) := by apply_instance
 
 @[simp]
 def is_scalar : G → Prop := is_rblade 0


### PR DESCRIPTION
Notably, this:

* Defines the set of `r`-blades, `Bᵣ r`, as things equal to a product of a scalar and orthogonal vectors and:
  * shows `mul_action G₀ (Bᵣ r)` - scalar multiples of an r-blade are an r-blade
  * shows `has_neg (Bᵣ r)` - negated r-blades are r-blades
* Defines the set of `r`-vectors, `Gᵣ r`, as a sum of  `Bᵣ r` and shows:
  * shows `add_comm_group (Gᵣ r)` - addition is commutative, `Gᵣ` is closed under it
  * shows `semimodule G₀ (Gᵣ r)` - `Gᵣ` behaves like a vector space
* Defines the set of multivectors with grades up to `r`, `Mᵣ r`, and shows:
  * shows `add_comm_group (Mᵣ r)` - addition is commutative, `Mᵣ` is closed under it
  * _states_ `semimodule G₀ (Mᵣ r)` - `Mᵣ` behaves like a vector space
  
