### PR TITLE
Update to the latest lean and mathlib versions

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lean-ga"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.27.0"
+lean_version = "leanprover-community/lean:3.30.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "8c72ca3ff2a87089846978886b8499aaa88f65ef"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "c7d094da6d3ced93ab034ba9d77519b4f9147124"}

--- a/src/geometric_algebra/from_mathlib/basic.lean
+++ b/src/geometric_algebra/from_mathlib/basic.lean
@@ -31,7 +31,7 @@ calc ι Q a * ι Q b + ι Q b * ι Q a
       = ι Q (a + b) * ι Q (a + b) - ι Q a * ι Q a - ι Q b * ι Q b :
           by { rw [(ι Q).map_add, mul_add, add_mul, add_mul], abel, }
   ... = ↑ₐ(Q $ a + b) - ↑ₐ(Q a) - ↑ₐ(Q b) :
-          by rw [ι_square_scalar, ι_square_scalar, ι_square_scalar]
+          by rw [ι_sq_scalar, ι_sq_scalar, ι_sq_scalar]
   ... = ↑ₐ(Q (a + b) - Q a - Q b) :
           by rw [←ring_hom.map_sub, ←ring_hom.map_sub]
   ... = ↑ₐ(quadratic_form.polar Q a b) : rfl

--- a/src/geometric_algebra/from_mathlib/versors.lean
+++ b/src/geometric_algebra/from_mathlib/versors.lean
@@ -51,7 +51,11 @@ namespace versors
           exact h_grade0 a, },
         { obtain ⟨a, rfl⟩ := set.mem_range.mpr hx,
           exact h_grade1 a, } })
-    (h_grade0 (1 : R))
+    (begin
+      convert h_grade0 (1 : R) using 1,
+      apply subtype.coe_injective,
+      simpa only [ring_hom.map_one],
+    end)
     h_mul v
 
   meta def inv_rev_tac : tactic unit :=
@@ -251,8 +255,9 @@ namespace versors
     group_with_zero (versors Q') :=
   { inv_zero := inv_zero,
     mul_inv_cancel := λ a ha, mul_inv_cancel' a $ λ ham, ha begin
-      refine (magnitude_aux_zero a f _).mp _,
+      refine (magnitude_aux_zero a f.out _).mp _,
       { intros r h,
+        rw ←ring_hom.map_zero at h,
         exact (algebra_map R' _).injective h, },
       { rw magnitude_apply at ham,
         replace ham := congr_arg (λ x : (⊥ : subalgebra R' $ clifford_algebra Q'), (x : clifford_algebra Q')) ham,
@@ -336,7 +341,11 @@ namespace spinors
           exact h_grade0 a, },
         { obtain ⟨_, _, ⟨a, rfl⟩, ⟨b, rfl⟩, rfl⟩ := set.mem_mul.mpr hx,
           exact h_grade2 a b, } })
-    (h_grade0 (1 : R))
+    (begin
+      convert h_grade0 (1 : R) using 1,
+      apply subtype.coe_injective,
+      simpa only [ring_hom.map_one],
+    end)
     h_mul v
 
   /-- Involute of a spinor is a spinor -/
@@ -418,8 +427,8 @@ def r_multivectors : algebra.filtration R (clifford_algebra Q) ℕ :=
       obtain ⟨na, hna⟩ := ha,
       obtain ⟨nb, hnb⟩ := hb,
       use (na ⊔ nb),
-      replace hna := submodule.le_def'.mpr (r_multivectors.mono Q le_sup_left) hna,
-      replace hnb := submodule.le_def'.mpr (r_multivectors.mono Q le_sup_right) hnb,
+      replace hna := set_like.le_def.mpr (r_multivectors.mono Q le_sup_left) hna,
+      replace hnb := set_like.le_def.mpr (r_multivectors.mono Q le_sup_right) hnb,
       exact submodule.add_mem _ hna hnb,
     }
   end,
@@ -433,7 +442,7 @@ namespace r_multivectors
 
   /-- Since the sets are monotonic, we can coerce up to a larger submodule -/
   instance (n r) : has_coe_t (r_multivectors Q n) (r_multivectors Q $ n + r) :=
-  { coe := λ x, ⟨x, submodule.le_def'.mpr ((r_multivectors Q).mono (nat.le_add_right n r)) x.prop⟩ }
+  { coe := λ x, ⟨x, set_like.le_def.mpr ((r_multivectors Q).mono (nat.le_add_right n r)) x.prop⟩ }
 
 end r_multivectors
 

--- a/src/geometric_algebra/nursery/chisolm.lean
+++ b/src/geometric_algebra/nursery/chisolm.lean
@@ -270,8 +270,8 @@ namespace Gᵣ
     (λ a, by {
       rw smul_neg, exact (Gᵣ r).neg_mem, })
 
-  -- now show via trivial proofs that Gᵣ is a semimodule (basically a vector space)
-  instance has_scalar (r : ℕ) : semimodule G₀ (Gᵣ r) :=
+  -- now show via trivial proofs that Gᵣ is a module (basically a vector space)
+  instance has_scalar (r : ℕ) : module G₀ (Gᵣ r) :=
   { smul := λ k v, ⟨k • v, smul_mem v.prop⟩,
     one_smul := λ v, subtype.eq $ one_smul _ v,
     mul_smul := λ k₁ k₂ v, subtype.eq $ mul_smul k₁ k₂ v,

--- a/src/geometric_algebra/nursery/graded.lean
+++ b/src/geometric_algebra/nursery/graded.lean
@@ -26,7 +26,7 @@ class graded_module_components
   -- all the types form commutative vector spaces
   -- TODO change to meaningful names
   [b: ∀ r, add_comm_monoid (A r)]
-  [c: ∀ r, semimodule (A 0) (A r)]
+  [c: ∀ r, module (A 0) (A r)]
 
 attribute [instance] graded_module_components.zc
 attribute [instance] graded_module_components.b

--- a/src/geometric_algebra/translations/hol_light.lean
+++ b/src/geometric_algebra/translations/hol_light.lean
@@ -4,6 +4,7 @@ import data.fintype.basic
 import algebra.big_operators
 import linear_algebra.basic
 import linear_algebra.tensor_product
+import order.symm_diff
 
 /-!
 # Derived from "Formalization of Geometric Algebra in HOL Light"
@@ -23,17 +24,15 @@ variables (n : ℕ)
 -- mapping from subsets of 1:n to coefficients
 abbreviation idx := finset (fin n)
 
-@[derive [add_comm_group, semimodule ℝ]]
+@[derive [add_comm_group, module ℝ]]
 def multivector : Type := idx n → ℝ
 
 variables {n}
 
-def sym_diff {α : Type*} [has_sup α] [has_sdiff α] (A B : α) : α := (A \ B) ⊔ (B \ A)
-
 /-- generic product indexed by a sign function -/
 def generic_prod (sgn : idx n → idx n → ℝ) (a b : multivector n)  : multivector n :=
 ∑ ai bi in finset.univ,
-  pi.single (sym_diff ai bi) ((a ai * b bi) * sgn ai bi)
+  pi.single (ai Δ bi) ((a ai * b bi) * sgn ai bi)
 
 /-- `generic_prod sgn` is a bilinear map -/
 def generic_prod.bilinear (sgn : idx n → idx n → ℝ) :

--- a/src/geometric_algebra/translations/ida.lean
+++ b/src/geometric_algebra/translations/ida.lean
@@ -61,7 +61,7 @@ instance : has_scalar ℝ multivector := ⟨λ r x,
   bivec := r • x.bivec,
   trivec := r • x.trivec}⟩
 
-instance : semimodule ℝ multivector :=
+instance : module ℝ multivector :=
 { smul := (•),
   smul_zero := λ _, ext _ _ (smul_zero _) (smul_zero _) (smul_zero _) (smul_zero _),
   zero_smul := λ _, ext _ _ (zero_smul _ _) (zero_smul _ _) (zero_smul _ _) (zero_smul _ _),

--- a/src/missing_from_mathlib.lean
+++ b/src/missing_from_mathlib.lean
@@ -34,10 +34,10 @@ by simp [sum_id, lift_nc_alg_hom, lift_nc_ring_hom, lift_nc, alg_hom.id, ring_ho
 
 -- `monoid_algebra` is missing some of the `finsupp` API:
 
-noncomputable def lsingle {k A : Type*} [semiring k] [semiring A] [semimodule k A] (i : G) : A →ₗ[k] add_monoid_algebra A G :=
+noncomputable def lsingle {k A : Type*} [semiring k] [semiring A] [module k A] (i : G) : A →ₗ[k] add_monoid_algebra A G :=
 finsupp.lsingle i
 
-@[simp] lemma lsingle_apply {k A : Type*} [semiring k] [semiring A] [semimodule k A] (i : G) (a : A) :
+@[simp] lemma lsingle_apply {k A : Type*} [semiring k] [semiring A] [module k A] (i : G) (a : A) :
   (lsingle i : _ →ₗ[k] _) a = finsupp.single i a := rfl
 
 end add_monoid_algebra
@@ -46,7 +46,7 @@ namespace submodule
 
 variables {R : Type*} {A : Type*} [comm_semiring R] [semiring A] [algebra R A]
 
-def one_eq_algebra_of_id_range : (1 : submodule R A) = (algebra.of_id R A).range :=
+def one_eq_algebra_of_id_range : (1 : submodule R A) = (algebra.of_id R A).range.to_submodule :=
 begin
   dunfold has_one.one,
   ext,
@@ -78,9 +78,9 @@ section semiring
 
 variables [comm_semiring R] [semiring A] [algebra R A] (S : center_submonoid R A)
 
-instance : has_coe_t (center_submonoid R A) (set A) := ⟨λ s, s.carrier⟩
-instance : has_mem A (center_submonoid R A) := ⟨λ x p, x ∈ (p : set A)⟩
-instance : has_coe_to_sort (center_submonoid R A) := ⟨_, λ p, {x : A // x ∈ p}⟩
+instance : set_like (center_submonoid R A) A :=
+{ coe := center_submonoid.carrier,
+  coe_injective' := λ x y h, by { cases x, cases y, congr' } }
 
 instance : nonempty S.to_sub_mul_action := ⟨⟨1, S.to_submonoid.one_mem⟩⟩
 


### PR DESCRIPTION
Putting up for now to let CI test this.

The main change here is that `semimodule` is gone, and now called `module`. This is especially convenient given a reviewer's confusion about what `semimodule` meant in our paper!